### PR TITLE
fix(template/index): post not show

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
                             <h2 class="card-title">{{ post.title }}</h2>
                             <p class="card-text text-muted h6">{{ post.author }} | {{ post.created_on}}  </p>
 
-                            <p class="card-text">{{post.content|safe|slice:":200" }}</p>
+                            <p class="card-text">{{post.content|safe|truncatechars_html:200 }}</p>
                             <a href="{% url 'post_detail' post.slug  %}" class="btn btn-primary">Read More &rarr;</a>
                         </div>
 


### PR DESCRIPTION
Root Cause
---
slice front 200 char may cause html content display error

Change
---
use `truncatechars_html` instead of `slice` for obtain html component